### PR TITLE
cdp_create_az_datalake.sh missing a newline escape

### DIFF
--- a/cdp_create_az_datalake.sh
+++ b/cdp_create_az_datalake.sh
@@ -84,7 +84,7 @@ else
     cdp datalake create-azure-datalake --datalake-name $1-cdp-dl \
         --environment-name $1-cdp-env \
         --cloud-provider-configuration managedIdentity="/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/$1-cdp-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/assumerIdentity",storageLocation="abfs://data@${1//-/}cdpsa.dfs.core.windows.net" \
-        --scale $2
+        --scale $2 \
         --tags $(flatten_tags $TAGS) \
         --database-availability-type NONE
 fi


### PR DESCRIPTION
The following failure is encountered due to the missing escape

Creating CDP datalake for repro-sup-x-env:
▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔


⛔  repro-sup-x-env: error during operation: datalake creation parse error: Unfinished JSON term at EOF at line 2, column 0
/workspace/cdp-one-click/cdp_create_az_datalake.sh: line 88: --tags: command not found

⛔  repro-sup-x-env: error during operation: creating Azure SDX Error creating Azure SDX